### PR TITLE
Add voice coding interview assistant example

### DIFF
--- a/11-voice-coding-assistant/.env.example
+++ b/11-voice-coding-assistant/.env.example
@@ -1,0 +1,7 @@
+# Rename this file to .env once you have filled in the below environment variables!
+
+# Your OpenAI API key is required for both voice transcription and chat responses
+OPENAI_API_KEY=
+
+# The chat model you want to use. gpt-4o is a good default
+OPENAI_MODEL=gpt-4o

--- a/11-voice-coding-assistant/requirements.txt
+++ b/11-voice-coding-assistant/requirements.txt
@@ -1,0 +1,4 @@
+openai
+speechrecognition
+pyaudio
+python-dotenv

--- a/11-voice-coding-assistant/voice_coding_assistant.py
+++ b/11-voice-coding-assistant/voice_coding_assistant.py
@@ -1,0 +1,71 @@
+from dotenv import load_dotenv
+import os
+import openai
+import speech_recognition as sr
+
+# Load environment variables from .env if present
+load_dotenv()
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
+
+if not OPENAI_API_KEY:
+    raise ValueError("OPENAI_API_KEY is not set in environment variables")
+
+openai.api_key = OPENAI_API_KEY
+
+recognizer = sr.Recognizer()
+
+# Use the default system microphone
+microphone = sr.Microphone()
+
+SYSTEM_PROMPT = (
+    "You are a helpful assistant that answers coding interview questions in a clear"
+    " and concise manner."
+)
+
+
+def listen_and_transcribe() -> str | None:
+    """Listen from the microphone and return the transcribed text."""
+    with microphone as source:
+        print("Listening... speak your question")
+        recognizer.adjust_for_ambient_noise(source)
+        audio = recognizer.listen(source)
+    print("Transcribing...")
+    try:
+        # Use Whisper API via speech_recognition for transcription
+        text = recognizer.recognize_whisper_api(audio, api_key=OPENAI_API_KEY)
+        return text
+    except Exception as exc:
+        print(f"Error during transcription: {exc}")
+        return None
+
+
+def ask_llm(question: str) -> str:
+    """Send the question to the LLM and return the response."""
+    response = openai.ChatCompletion.create(
+        model=OPENAI_MODEL,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": question},
+        ],
+    )
+    return response.choices[0].message.content.strip()
+
+
+def main() -> None:
+    print("Coding Interview Voice Assistant. Press Ctrl+C to exit.")
+    while True:
+        try:
+            question = listen_and_transcribe()
+            if question:
+                print(f"\nYou asked: {question}\n")
+                answer = ask_llm(question)
+                print(f"Assistant: {answer}\n")
+        except KeyboardInterrupt:
+            print("\nExiting...")
+            break
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a new example `11-voice-coding-assistant`
- use `speech_recognition` and OpenAI to convert spoken questions to text
- send the transcribed question to an LLM and print the response
- include environment variables and package requirements

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6871ab2c0e1c833298e12443896c3b77